### PR TITLE
Fixed invalid "this" in closure

### DIFF
--- a/lib/triggers/cleverbotTrigger.js
+++ b/lib/triggers/cleverbotTrigger.js
@@ -55,8 +55,8 @@ CleverbotTrigger.prototype._respond = function(toId, message) {
 		this.winston.info(this.cleverbot.params);
 		var that = this;
 		this.cleverbot.write(message, function(response) {
-			this.winston.info("Cleverbot responded with params:");
-			this.winston.info(that.cleverbot.params);
+			that.winston.info("Cleverbot responded with params:");
+			that.winston.info(that.cleverbot.params);
 			if (response.message === "<html>") {
 				that.cleverbot.params.sessionid = "";
 			}


### PR DESCRIPTION
Fixes a crash in cleverbotTrigger:

```
steam-chat-bot/lib/triggers/cleverbotTrigger.js:58
            this.winston.info("Cleverbot responded with params:");
                        ^
TypeError: Cannot read property 'info' of undefined
    at steam-chat-bot/lib/triggers/cleverbotTrigger.js:58:16
```
