### PR TITLE
Add more node-steam apis

### DIFF
--- a/lib/chatBot.js
+++ b/lib/chatBot.js
@@ -421,7 +421,6 @@ ChatBot.prototype.cancelTrade = function(steamID) {
 	this.steamClient.cancelTrade(steamID);
 }
 
-ChatBot.prototype.webLogOn = function()
 // "Private" functions
 
 ChatBot.prototype._updatePersonaState = function() {

--- a/lib/chatBot.js
+++ b/lib/chatBot.js
@@ -2,6 +2,7 @@ var fs = require("fs");
 var steam = require("steam");
 var winston = require("winston");
 var _ = require("underscore");
+var SteamTrade = require('steam-trade');
 //var SteamTrade = require("steam-trade"); // change to "steam-trade" if not running from the same directory
 
 var TriggerFactory = require("./triggerFactory.js").TriggerFactory;
@@ -24,6 +25,7 @@ var ChatBot = function(username, password, options) {
 
 	this.steamClient = options.client || new steam.SteamClient();
 //	this.steamTrade = new SteamTrade
+	this.steamTrade = new SteamTrade();
 	this.username = username;
 	this.password = password;
 	if(options.guardCode) {
@@ -35,6 +37,10 @@ var ChatBot = function(username, password, options) {
 	this.games = [];
 	this.logFile = undefined;
 	this.cookie = undefined;
+
+	this.acceptTrade = options.acceptTrade || false;
+	this.maingroup = options.maingroup || undefined;
+
 	this.autojoinFile = options.autojoinFile || "bot." + this.username+".autojoin"; this.autojoinRooms = undefined;
 
 	this.winston.add(winston.transports.Console,{
@@ -127,7 +133,12 @@ var ChatBot = function(username, password, options) {
 	this.steamClient.on("chatMsg",         function(roomId, message, type, chatterId) { that._onChatMsg(roomId, message, type, chatterId); });
 	this.steamClient.on("chatStateChange", function(stateChange, chatterActedOn, steamChatId, actedOnBy) { that._onChatStateChange(stateChange, chatterActedOn, steamChatId, actedOnBy); });
 	this.steamClient.on("sentry",          function(sentry) { that._onSentry(sentry); });
-
+	this.steamClient.on('webSessionID',    function(sessionID) { that._onWebSessionID(sessionID); });
+	this.steamClient.on('tradeOffers', 	   function(number) { that._onTradeOffers(number); });
+	this.steamClient.on('tradeProposed',   function(tradeID, steamID) { that._onTradeProposed(tradeID, steamID, that.acceptTrade); });
+	this.steamClient.on('tradeResult',     function(tradeID, result, steamID) { that._onTradeResult(tradeID, result, steamID) });
+	this.steamClient.on('sessionStart',    function(steamID) { that._onSessionStart(steamID) });
+	this.steamClient.on('announcement',    function(groupID, headline) { that._onAnnouncement(that.maingroup, headLine); });
 /*
 // These events exist in node-steam, but are only half-implemented in this file...
 	this.steamClient.on("user", function(obscureData)              {that._onUser(obscureData); });
@@ -369,6 +380,48 @@ ChatBot.prototype.groups = function() {
 	return this.steamClient.groups;
 }
 
+ChatBot.prototype.logOff = function() {
+	this.winston.info('Chat bot ' + this.username + ' logging off');
+	this.steamClient.logOff();
+}
+
+ChatBot.prototype.chatInvite = function(chatSteamID, invitedSteamID) {
+	this.winston.info('Inviting ' + invitedSteamID + ' to chat ' + chatSteamID);
+	this.steamClient.chatInvite(chatSteamID, invitedSteamID);
+}
+
+ChatBot.prototype.getSteamLevel = function(steamids) {
+	this.winston.info('Getting steam level for ' + steamids.toString());
+	var that = this;
+	this.steamClient.getSteamLevel(steamids, function(levels) {
+		that.winston.info(levels);
+	});
+}
+
+ChatBot.prototype.setIgnoreFriend = function(steamID, setIgnore) {
+	this.winston.info('Setting ' + steamID + ' block to ' + setIgnore);
+	var that = this.
+	this.steamClient.setIgnoreFriend(steamID, setIgnore, function(callback) {
+		that.winston.info(callback); //i don't know what this callback does
+	});
+}
+
+ChatBot.prototype.trade = function(steamID) {
+	this.winston.info('Sending trade request to ' + steamID);
+	this.steamClient.trade(steamID);
+}
+
+ChatBot.prototype.respondToTrade = function(tradeID, bool) {
+	if(bool === true) { this.steamClient.respondToTrade(tradeID, true); this.winston.info('Accepting trade'); }
+	else { this.steamClient.respondToTrade(tradeID, false); this.winston.info('Denying trade'); }
+}
+
+ChatBot.prototype.cancelTrade = function(steamID) {
+	this.winston.info('Cancelling trade to ' + steamID);
+	this.steamClient.cancelTrade(steamID);
+}
+
+ChatBot.prototype.webLogOn = function()
 // "Private" functions
 
 ChatBot.prototype._updatePersonaState = function() {
@@ -550,7 +603,42 @@ ChatBot.prototype._onSentry = function(sentry) {
 	}
 }
 
+ChatBot.prototype._onWebSessionID = function(sessionid) {
+	this.steamTrade.sessionID = sessionid;
+	this.winston.info('New sessionID: ', sessionid);
+	var that = this;
+	this.steamClient.webLogOn(function(cookie) {
+		that.winston.info('New cookie: ', cookie);
+		cookie.forEach(function(part) {
+			that.steamTrade.setCookie(part.trim());
+		});
+        that.winston.info('Logged into Steam Web API at ' + new Date().toString());
+    });
+}
 
+ChatBot.prototype._onTradeOffers = function(number) {
+	this.winston.info('New trade offer count: ' + number);
+}
+
+ChatBot.prototype._onTradeProposed = function(tradeID, steamID, bool) {
+	this.winston.info('Received trade request from ' + steamID);
+	if(bool) this.respondToTrade(tradeID, true);
+	else this.respondToTrade(tradeID, false);
+}
+
+ChatBot.prototype._onTradeResult = function(tradeID, result, steamID) {
+	this.winston.info(result + ' from trade with ' + steamID);
+}
+
+ChatBot.prototype._onSessionStart = function(steamID) {
+	this.winston.info('Trade with ' + steamID + ' initialized');
+	this.steamTrade.open(steamID)
+}
+
+ChatBot.prototype._onAnnouncement = function(groupID, headline) {
+	if(this.maingroup !== undefined) this.winston.info(groupID + ' posted announcement with title ' + '"' + headline + '"');
+	else this.winston.warn('maingroup is undefined!');
+}
 /*
  * This crap is possibly not implemented correctly/fully. Don't expect it to work right without testing it. For info, see https://github.com/seishun/node-steam
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "steam-chat-bot",
   "homepage": "https://github.com/Efreak/node-steam-chat-bot",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "bugs": {
     "url": "http://github.com/Efreak/node-steam-chat-bot/issues"
   },

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "sinon": "^1.12.1",
     "sqlite3": "^3.0.2",
     "steam": "^0.6.8",
+    "steam-trade": "git://github.com/seishun/node-steam-trade.git",
     "tinycache": "^1.1.0",
     "touch": "0.0.3",
     "tumblr.js": "0.0.x",


### PR DESCRIPTION
#52

Things I didn't add and the reason I didn't add them:

```
webLogOn - this can't be used outside of steamClient.on('websessionid'), which I've already made a listener for
requestFriendData - I don't know how this works
.on('friendMessageEchoToSender') - I don't know what this is 
```

I tested everything in this pack that I could (about 95%) and they all worked without any problems. They also do not cause any errors when not being used. 

I will do `npm publish` and do the release on github when this is merged.
